### PR TITLE
ci: fix semantic-release configuration for Go

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,20 @@
+{
+  "branches": ["main"],
+  "plugins": [
+    ["@semantic-release/commit-analyzer", {
+      "preset": "conventionalcommits",
+      "releaseRules": [
+        {"type": "fix", "release": "patch"},
+        {"type": "feat", "release": "minor"},
+        {"type": "perf", "release": "patch"},
+        {"type": "docs", "scope": "README", "release": "patch"},
+        {"scope": "no-release", "release": false},
+        {"breaking": true, "release": "major"}
+      ]
+    }],
+    ["@semantic-release/release-notes-generator", {
+      "preset": "conventionalcommits"
+    }],
+    "@semantic-release/github"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,14 @@
 {
+  "name": "nix-foundry",
   "private": true,
+  "version": "0.0.0-development",
   "devDependencies": {
     "prettier": "^3.5.2",
-    "@prettier/plugin-xml": "^0.10.0"
+    "@prettier/plugin-xml": "^0.10.0",
+    "@semantic-release/commit-analyzer": "^9.0.2",
+    "@semantic-release/github": "^8.0.7",
+    "@semantic-release/release-notes-generator": "^10.0.3",
+    "conventional-changelog-conventionalcommits": "^4.6.3",
+    "semantic-release": "^19.0.5"
   }
 }


### PR DESCRIPTION
## Description

Fix semantic-release configuration for Go by adding a proper `.releaserc.json` file and updating `package.json` with required properties. This resolves the error where production releases were failing due to npm plugin validation.

## Type of Change
- [ ] 🚀 New feature (non-breaking change adding functionality)
- [x] 🛠️ Bug fix (non-breaking change fixing an issue)
- [ ] ⚠️ Breaking change (fix or feature causing existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🧹 Code refactor
- [x] 🔧 Build/CI configuration change
- [ ] ⬆️ Dependency update

## Testing
- [ ] Added/updated unit tests
- [ ] Added/updated integration tests
- [x] Tested manually
- [ ] No tests required for this change

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Context
The error was occurring because semantic-release was trying to validate the npm package configuration in a Go project. By explicitly configuring semantic-release to only use GitHub releases (and not npm publishing), the issue is resolved.
