### PR TITLE
chore: standardize commit types & add v prefix to release version tags

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,12 +1,21 @@
 {
   "branches": ["main"],
+  "tagFormat": "v${version}",
   "plugins": [
     ["@semantic-release/commit-analyzer", {
       "preset": "conventionalcommits",
       "releaseRules": [
-        {"type": "fix", "release": "patch"},
         {"type": "feat", "release": "minor"},
+        {"type": "fix", "release": "patch"},
         {"type": "perf", "release": "patch"},
+        {"type": "docs", "release": "patch"},
+        {"type": "style", "release": "patch"},
+        {"type": "refactor", "release": "patch"},
+        {"type": "test", "release": "patch"},
+        {"type": "build", "release": "patch"},
+        {"type": "ci", "release": "patch"},
+        {"type": "chore", "release": "patch"},
+        {"type": "revert", "release": "patch"},
         {"type": "docs", "scope": "README", "release": "patch"},
         {"scope": "no-release", "release": false},
         {"breaking": true, "release": "major"}
@@ -15,6 +24,11 @@
     ["@semantic-release/release-notes-generator", {
       "preset": "conventionalcommits"
     }],
-    "@semantic-release/github"
+    ["@semantic-release/github", {
+      "releasedLabels": ["released"],
+      "successComment": "🎉 This PR is included in version ${nextRelease.version}",
+      "failTitle": "❌ Release failed",
+      "failComment": "Release failed with error: ${error.message}"
+    }]
   ]
 }

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -14,8 +14,7 @@ module.exports = {
         'test',
         'build',
         'ci',
-        'deps',
-        'go',
+        'chore',
         'revert'
       ]
     ],


### PR DESCRIPTION
## Description

Standardized commit types to strictly follow the Conventional Commits specification. Removed custom commit types ('deps', 'go') and ensured all standard types are properly mapped to their semantic versioning impact.

## Type of Change
- [ ] 🚀 New feature (non-breaking change adding functionality)
- [ ] 🛠️ Bug fix (non-breaking change fixing an issue)
- [ ] ⚠️ Breaking change (fix or feature causing existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🧹 Code refactor
- [x] 🔧 Build/CI configuration change
- [ ] ⬆️ Dependency update

## Testing
- [ ] Added/updated unit tests
- [ ] Added/updated integration tests
- [x] Tested manually
- [ ] No tests required for this change

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Context
This change ensures we're using only the official conventional commit types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, and revert. All types are now properly mapped to their semantic versioning impact.
