### PR TITLE
fix(ci): only create beta releases on PRs

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -66,7 +66,7 @@ jobs:
 
   beta_release:
     name: "Create Beta Release"
-    if: true
+    if: github.event_name == 'pull_request'
     needs: [lint, test]
     runs-on: ubuntu-latest
     outputs:


### PR DESCRIPTION
## Description
Fixed the beta release job in the CI/CD workflow to only run on pull requests instead of all events. This prevents beta releases from being created on the main branch, which was causing artifact upload conflicts.

## Type of Change
- [x] 🔧 Build/CI configuration change
- [ ] 🚀 New feature (non-breaking change adding functionality)
- [ ] 🛠️ Bug fix (non-breaking change fixing an issue)
- [ ] ⚠️ Breaking change (fix or feature causing existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🧹 Code refactor
- [ ] ⬆️ Dependency update

## Testing
- [x] Tested manually
- [ ] Added/updated unit tests
- [ ] Added/updated integration tests
- [ ] No tests required for this change

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Context
The issue was occurring because the beta release job was configured to run on all events (`if: true`), including pushes to the main branch. This was causing conflicts with the artifact upload step since beta releases should only be created for pull requests. The fix changes the condition to `if: github.event_name == 'pull_request'` to ensure beta releases are only created during PR workflows.
